### PR TITLE
Platform support and scalaz dependency update.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 project/target
 target
+.lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ jdk:
   - oraclejdk7
 
 install: /bin/true
-script: ./sbt -J-Xss1M -J-XX:MaxPermSize=128M ";++${TRAVIS_SCALA_VERSION};clean;compile;test"
+script: ./sbt -J-Xss1M -J-XX:MaxPermSize=256M ";++${TRAVIS_SCALA_VERSION};clean;compile;test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: scala
 scala:
   - 2.9.2
+  - 2.9.3
+  - 2.10.0
+  - 2.10.1
 jdk:
   - oraclejdk7
 
 install: /bin/true
-script: ./sbt -J-Xss1M -J-XX:MaxPermSize=128M ";clean;compile;test"
+script: ./sbt -J-Xss1M -J-XX:MaxPermSize=128M ";++${TRAVIS_SCALA_VERSION};clean;compile;test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.0
+sbt.version=0.12.3

--- a/project/build.scala
+++ b/project/build.scala
@@ -4,13 +4,15 @@ import Keys._
 object build extends Build {
   type Sett = Project.Setting[_]
 
-  val scalazVersion = "7.0.0-M3"
+  val scalazVersion = "7.0.0"
+
+  def specsVersion(scalaVersion: String) =
+    if (scalaVersion startsWith "2.9") "1.12.4.1" else "1.12.3"
 
   lazy val standardSettings = Defaults.defaultSettings ++ List[Sett](
     organization := "org.purefn"
-  , scalaVersion := "2.9.2"
-  , crossScalaVersions := List("2.9.2", "2.10.0-M5")
-  , crossVersion := CrossVersion.full
+  , scalaVersion := "2.10.1"
+  , crossScalaVersions := List("2.9.2", "2.9.3", "2.10.1")
   , resolvers += "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases"
   , scalacOptions <++= (scalaVersion).map((sv: String) ⇒ List("-deprecation", "-unchecked", "-Ywarn-value-discard") ++ (if(sv.contains("2.10")) None else Some("-Ydependent-method-types")))
   , scalacOptions in (Compile, doc) <++= (baseDirectory in LocalProject("bytestring")).map {
@@ -24,9 +26,9 @@ object build extends Build {
   , settings = standardSettings ++ Unidoc.settings ++ List[Sett](
       name := "bytestring"
     , libraryDependencies ++= List(
-        "org.scalaz" %% "scalaz-core" % scalazVersion cross CrossVersion.full
-      , "org.scalaz" %% "scalaz-effect" % scalazVersion cross CrossVersion.full
-      , "org.scalaz" %% "scalaz-iteratee" % scalazVersion cross CrossVersion.full
+        "org.scalaz" %% "scalaz-core" % scalazVersion
+      , "org.scalaz" %% "scalaz-effect" % scalazVersion
+      , "org.scalaz" %% "scalaz-iteratee" % scalazVersion
       )
     )
   , aggregate = List(scalacheckBinding, tests)
@@ -38,7 +40,7 @@ object build extends Build {
   , dependencies = List(bytestring)
   , settings     = standardSettings ++ List[Sett](
       name := "bytestring-scalacheck-binding"
-    , libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.10.0" cross CrossVersion.full
+    , libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.10.0"
     )
   )
 
@@ -48,11 +50,10 @@ object build extends Build {
   , dependencies = List(bytestring, scalacheckBinding % "test")
   , settings     = standardSettings ++ List[Sett](
       name := "bytestring-tests"
-    , libraryDependencies ++= List(
-        "org.specs2" %% "specs2" % "1.12" % "test"
+    , libraryDependencies <++= scalaVersion(v => List(
+        "org.specs2" %% "specs2" % specsVersion(v) % "test"
       , "org.scalaz" %% "scalaz-scalacheck-binding" % scalazVersion % "test"
-      )
+      ))
     )
   )
 }
-

--- a/sbt
+++ b/sbt
@@ -4,22 +4,22 @@
 # Author: Paul Phillips <paulp@typesafe.com>
 
 # todo - make this dynamic
-declare -r sbt_release_version=0.12.0
+declare -r sbt_release_version=0.12.2
 declare -r sbt_snapshot_version=0.13.0-SNAPSHOT
 
-unset sbt_jar sbt_dir sbt_create sbt_snapshot sbt_launch_dir
-unset scala_version java_home sbt_explicit_version
-unset verbose debug quiet
+declare sbt_jar sbt_dir sbt_create sbt_snapshot sbt_launch_dir
+declare scala_version java_home sbt_explicit_version
+declare verbose debug quiet noshare batch trace_level log_level
 
 for arg in "$@"; do
   case $arg in
-    -q|-quiet)  quiet=1 ;;
-            *)          ;;
+    -q|-quiet)  quiet=true ;;
+            *)             ;;
   esac
 done
 
 build_props_sbt () {
-  if [[ -f project/build.properties ]]; then
+  if [[ -r project/build.properties ]]; then
     versionLine=$(grep ^sbt.version project/build.properties)
     versionString=${versionLine##sbt.version=}
     echo "$versionString"
@@ -32,7 +32,7 @@ update_build_props_sbt () {
 
   if [[ $ver == $old ]]; then
     return
-  elif [[ -f project/build.properties ]]; then
+  elif [[ -r project/build.properties ]]; then
     perl -pi -e "s/^sbt\.version=.*\$/sbt.version=${ver}/" project/build.properties
     grep -q '^sbt.version=' project/build.properties || echo "sbt.version=${ver}" >> project/build.properties
 
@@ -57,7 +57,7 @@ sbt_version () {
 }
 
 echoerr () {
-  [[ -z $quiet ]] && echo 1>&2 "$@"
+  [[ -z $quiet ]] && echo "$@" >&2
 }
 vlog () {
   [[ $verbose || $debug ]] && echoerr "$@"
@@ -80,18 +80,6 @@ get_script_path () {
   fi
 }
 
-# a ham-fisted attempt to move some memory settings in concert
-# so they need not be dicked around with individually.
-get_mem_opts () {
-  local mem=${1:-1536}
-  local perm=$(( $mem / 4 ))
-  (( $perm > 256 )) || perm=256
-  (( $perm < 1024 )) || perm=1024
-  local codecache=$(( $perm / 2 ))
-
-  echo "-Xms${mem}m -Xmx${mem}m -XX:MaxPermSize=${perm}m -XX:ReservedCodeCacheSize=${codecache}m"
-}
-
 die() {
   echo "Aborting: $@"
   exit 1
@@ -105,15 +93,11 @@ make_url () {
   echo "http://typesafe.artifactoryonline.com/typesafe/ivy-$category/$groupid/sbt-launch/$version/sbt-launch.jar"
 }
 
-declare -r default_jvm_opts="-Dfile.encoding=UTF8"
-declare -r default_sbt_opts="-XX:+CMSClassUnloadingEnabled"
-declare -r default_sbt_mem=1536
+declare -r default_jvm_opts="-Dfile.encoding=UTF8 -XX:MaxPermSize=256m -Xms512m -Xmx1g -XX:+CMSClassUnloadingEnabled -XX:+UseConcMarkSweepGC"
 declare -r noshare_opts="-Dsbt.global.base=project/.sbtboot -Dsbt.boot.directory=project/.boot -Dsbt.ivy.home=project/.ivy"
-declare -r sbt_opts_file=".sbtopts"
-declare -r jvm_opts_file=".jvmopts"
 declare -r latest_28="2.8.2"
-declare -r latest_29="2.9.2"
-declare -r latest_210="2.10.0-SNAPSHOT"
+declare -r latest_29="2.9.3"
+declare -r latest_210="2.10.0"
 
 declare -r script_path=$(get_script_path "$BASH_SOURCE")
 declare -r script_dir="$(dirname $script_path)"
@@ -123,8 +107,9 @@ declare -r script_name="$(basename $script_path)"
 declare java_cmd=java
 declare sbt_launch_dir="$script_dir/.lib"
 declare sbt_universal_launcher="$script_dir/lib/sbt-launch.jar"
-declare sbt_mem=$default_sbt_mem
 declare sbt_jar=$sbt_universal_launcher
+declare sbt_opts_file=.sbtopts
+declare jvm_opts_file=.jvmopts
 
 # pull -J and -D options to give to java.
 declare -a residual_args
@@ -132,8 +117,17 @@ declare -a java_args
 declare -a scalac_args
 declare -a sbt_commands
 
+# args to jvm/sbt via files or environment variables
+declare -a extra_jvm_opts extra_sbt_opts
+
+# if set, use JAVA_HOME over java found in path
+[[ -e "$JAVA_HOME/bin/java" ]] && java_cmd="$JAVA_HOME/bin/java"
+
+# use ~/.sbt/launch to store sbt jars if script_dir is not writable
+[[ -w "$sbt_launch_dir" ]] || sbt_launch_dir="$HOME/.sbt/launch"
+
 build_props_scala () {
-  if [[ -f project/build.properties ]]; then
+  if [[ -r project/build.properties ]]; then
     versionLine=$(grep ^build.scala.versions project/build.properties)
     versionString=${versionLine##build.scala.versions=}
     echo ${versionString%% .*}
@@ -144,16 +138,26 @@ execRunner () {
   # print the arguments one to a line, quoting any containing spaces
   [[ $verbose || $debug ]] && echo "# Executing command line:" && {
     for arg; do
-      if printf "%s\n" "$arg" | grep -q ' '; then
-        printf "\"%s\"\n" "$arg"
-      else
-        printf "%s\n" "$arg"
+      if [[ -n "$arg" ]]; then
+        if printf "%s\n" "$arg" | grep -q ' '; then
+          printf "\"%s\"\n" "$arg"
+        else
+          printf "%s\n" "$arg"
+        fi
       fi
     done
     echo ""
   }
 
-  exec "$@"
+  if [[ -n $batch ]]; then
+    # the only effective way I've found to avoid sbt hanging when backgrounded.
+    exec 0<&-
+    ( "$@" & )
+    # I'm sure there's some way to get our hands on the pid and wait for it
+    # but it exceeds my present level of ambition.
+  else
+    exec "$@"
+  fi
 }
 
 sbt_groupid () {
@@ -220,14 +224,14 @@ download_url () {
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi
-  } && [[ -f "$jar" ]]
+  } && [[ -r "$jar" ]]
 }
 
 acquire_sbt_jar () {
   sbt_url="$(jar_url)"
   sbt_jar="$(jar_file $(sbt_version))"
 
-  [[ -f "$sbt_jar" ]] || download_url "$sbt_url" "$sbt_jar"
+  [[ -r "$sbt_jar" ]] || download_url "$sbt_url" "$sbt_jar"
 }
 
 usage () {
@@ -238,17 +242,17 @@ Usage: $script_name [options]
   -v | -verbose      this runner is chattier
   -d | -debug        set sbt log level to Debug
   -q | -quiet        set sbt log level to Error
+  -trace <level>     display stack traces with a max of <level> frames (default: -1, traces suppressed)
   -no-colors         disable ANSI color codes
   -sbt-create        start sbt even if current directory contains no sbt project
   -sbt-dir   <path>  path to global settings/plugins directory (default: ~/.sbt/<version>)
   -sbt-boot  <path>  path to shared boot directory (default: ~/.sbt/boot in 0.11+)
   -ivy       <path>  path to local Ivy repository (default: ~/.ivy2)
-  -mem    <integer>  set memory options (default: $sbt_mem, which is
-                       $(get_mem_opts $sbt_mem) )
   -no-share          use all local caches; no sharing
   -offline           put sbt in offline mode
   -jvm-debug <port>  Turn on JVM debugging, open at the given port.
   -batch             Disable interactive mode
+  -prompt <expr>     Set the sbt prompt; in expr, 's' is the State and 'e' is Extracted
 
   # sbt version (default: from project/build.properties if present, else latest release)
   !!! The only way to accomplish this pre-0.12.0 if there is a build.properties file which
@@ -264,21 +268,23 @@ Usage: $script_name [options]
   -210                      use $latest_210
   -scala-home <path>        use the scala build at the specified directory
   -scala-version <version>  use the specified version of scala
+  -binary-version <version> use the specified scala version when searching for dependencies
 
   # java version (default: java from PATH, currently $(java -version |& grep version))
   -java-home <path>         alternate JAVA_HOME
 
-  # jvm options and output control
-  JAVA_OPTS     environment variable holding jvm args, if unset uses "$default_jvm_opts"
-  SBT_OPTS      environment variable holding jvm args, if unset uses "$default_sbt_opts"
-  .jvmopts      if file is in sbt root, it is prepended to the args given to the jvm
-  .sbtopts      if file is in sbt root, it is prepended to the args given to **sbt**
-  -Dkey=val     pass -Dkey=val directly to the jvm
-  -J-X          pass option -X directly to the jvm (-J is stripped)
-  -S-X          add -X to sbt's scalacOptions (-J is stripped)
+  # passing options to the jvm - note it does NOT use JAVA_OPTS due to pollution
+  # The default set is used if JVM_OPTS is unset and no -jvm-opts file is found
+  <default>        $default_jvm_opts
+  JVM_OPTS         environment variable holding jvm args
+  -jvm-opts <path> file containing jvm args (if not given, .jvmopts in project root is used if present)
+  -Dkey=val        pass -Dkey=val directly to the jvm
+  -J-X             pass option -X directly to the jvm (-J is stripped)
 
-In the case of duplicated or conflicting options, the order above
-shows precedence: JAVA_OPTS lowest, command line options highest.
+  # passing options to sbt, OR to this runner
+  SBT_OPTS         environment variable holding sbt args
+  -sbt-opts <path> file containing sbt args (if not given, .sbtopts in project root is used if present)
+  -S-X             add -X to sbt's scalacOptions (-S is stripped)
 EOM
 }
 
@@ -304,11 +310,11 @@ addResolver () {
 addDebugger () {
   addJava "-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"
 }
-get_jvm_opts () {
-  # echo "${JAVA_OPTS:-$default_jvm_opts}"
-  # echo "${SBT_OPTS:-$default_sbt_opts}"
-
-  [[ -f "$jvm_opts_file" ]] && cat "$jvm_opts_file"
+setScalaVersion () {
+  addSbt "set scalaVersion in ThisBuild := \"$1\""
+  if [[ "$1" == *SNAPSHOT* ]]; then
+    addResolver Opts.resolver.sonatypeSnapshots
+  fi
 }
 
 process_args ()
@@ -325,29 +331,33 @@ process_args ()
   while [[ $# -gt 0 ]]; do
     case "$1" in
        -h|-help) usage; exit 1 ;;
-    -v|-verbose) verbose=1 && shift ;;
-      -d|-debug) debug=1 && shift ;;
-      -q|-quiet) quiet=1 && shift ;;
+    -v|-verbose) verbose=true && log_level=Info && shift ;;
+      -d|-debug) debug=true && log_level=Debug && shift ;;
+      -q|-quiet) quiet=true && log_level=Error && shift ;;
 
+         -trace) require_arg integer "$1" "$2" && trace_level=$2 && shift 2 ;;
            -ivy) require_arg path "$1" "$2" && addJava "-Dsbt.ivy.home=$2" && shift 2 ;;
-           -mem) require_arg integer "$1" "$2" && sbt_mem="$2" && shift 2 ;;
      -no-colors) addJava "-Dsbt.log.noformat=true" && shift ;;
-      -no-share) addJava "$noshare_opts" && shift ;;
+      -no-share) noshare=true && shift ;;
       -sbt-boot) require_arg path "$1" "$2" && addJava "-Dsbt.boot.directory=$2" && shift 2 ;;
        -sbt-dir) require_arg path "$1" "$2" && sbt_dir="$2" && shift 2 ;;
      -debug-inc) addJava "-Dxsbt.inc.debug=true" && shift ;;
        -offline) addSbt "set offline := true" && shift ;;
      -jvm-debug) require_arg port "$1" "$2" && addDebugger $2 && shift 2 ;;
-         -batch) exec </dev/null && shift ;;
+         -batch) batch=true && shift ;;
+        -prompt) require_arg "expr" "$1" "$2" && addSbt "set shellPrompt in ThisBuild := (s => { val e = Project.extract(s) ; $2 })" && shift 2 ;;
 
     -sbt-create) sbt_create=true && shift ;;
   -sbt-snapshot) sbt_explicit_version=$sbt_snapshot_version && shift ;;
        -sbt-jar) require_arg path "$1" "$2" && sbt_jar="$2" && shift 2 ;;
    -sbt-version) require_arg version "$1" "$2" && sbt_explicit_version="$2" && shift 2 ;;
 -sbt-launch-dir) require_arg path "$1" "$2" && sbt_launch_dir="$2" && shift 2 ;;
- -scala-version) require_arg version "$1" "$2" && addSbt "set scalaVersion := \"$2\"" && shift 2 ;;
-    -scala-home) require_arg path "$1" "$2" && addSbt "set scalaHome in ThisBuild := Some(file(\"$2\"))" && shift 2 ;;
+ -scala-version) require_arg version "$1" "$2" && setScalaVersion "$2" && shift 2 ;;
+-binary-version) require_arg version "$1" "$2" && addSbt "set scalaBinaryVersion in ThisBuild := \"$2\"" && shift 2 ;;
+    -scala-home) require_arg path "$1" "$2" && addSbt "set every scalaHome := Some(file(\"$2\"))" && shift 2 ;;
      -java-home) require_arg path "$1" "$2" && java_cmd="$2/bin/java" && shift 2 ;;
+      -sbt-opts) require_arg path "$1" "$2" && sbt_opts_file="$2" && shift 2 ;;
+      -jvm-opts) require_arg path "$1" "$2" && jvm_opts_file="$2" && shift 2 ;;
 
             -D*) addJava "$1" && shift ;;
             -J*) addJava "${1:2}" && shift ;;
@@ -359,35 +369,33 @@ process_args ()
               *) addResidual "$1" && shift ;;
     esac
   done
-
-  [[ $debug ]] && {
-    case $(sbt_version) in
-     0.7.*) addSbt "debug" ;;
-         *) addSbt "set logLevel in Global := Level.Debug" ;;
-    esac
-  }
-  [[ $quiet ]] && {
-    case $(sbt_version) in
-     0.7.*) ;;
-         *) addSbt "set logLevel in Global := Level.Error" ;;
-    esac
-  }
 }
 
-# if .sbtopts exists, prepend its contents to $@ so it can be processed by this runner
-[[ -f "$sbt_opts_file" ]] && {
-  sbtargs=()
-  while IFS= read -r arg; do
-    sbtargs=( "${sbtargs[@]}" "$arg" )
-  done <"$sbt_opts_file"
 
-  set -- "${sbtargs[@]}" "$@"
-}
-
-# process the combined args, then reset "$@" to the residuals
+# process the direct command line arguments
 process_args "$@"
+
+# if there are file/environment sbt_opts, process again so we
+# can supply args to this runner
+if [[ -r "$sbt_opts_file" ]]; then
+  readarray -t extra_sbt_opts < "$sbt_opts_file"
+elif [[ -n "$SBT_OPTS" ]]; then
+  extra_sbt_opts=( $SBT_OPTS )
+fi
+
+[[ -n $extra_sbt_opts ]] && process_args "${extra_sbt_opts[@]}"
+
+# reset "$@" to the residual args
 set -- "${residual_args[@]}"
 argumentCount=$#
+
+# only exists in 0.12+
+setTraceLevel() {
+  case $(sbt_version) in
+     0.{7,10,11}.*) echoerr "Cannot set trace level in sbt version $(sbt_version)" ;;
+                 *) addSbt "set every traceLevel := $trace_level" ;;
+  esac
+}
 
 # set scalacOptions if we were given any -S opts
 [[ ${#scalac_args[@]} -eq 0 ]] || addSbt "set scalacOptions in ThisBuild += \"${scalac_args[@]}\""
@@ -402,7 +410,7 @@ echoerr "Detected sbt version $(sbt_version)"
 (( $argumentCount > 0 )) || echo "Starting $script_name: invoke with -help for other options"
 
 # verify this is an sbt dir or -create was given
-[[ -f ./build.sbt || -d ./project || -n "$sbt_create" ]] || {
+[[ -r ./build.sbt || -d ./project || -n "$sbt_create" ]] || {
   cat <<EOM
 $(pwd) doesn't appear to be an sbt project.
 If you want to start sbt anyway, run:
@@ -413,29 +421,46 @@ EOM
 }
 
 # pick up completion if present; todo
-[[ -f .sbt_completion.sh ]] && source .sbt_completion.sh
+[[ -r .sbt_completion.sh ]] && source .sbt_completion.sh
 
 # no jar? download it.
-[[ -f "$sbt_jar" ]] || acquire_sbt_jar || {
+[[ -r "$sbt_jar" ]] || acquire_sbt_jar || {
   # still no jar? uh-oh.
   echo "Download failed. Obtain the jar manually and place it at $sbt_jar"
   exit 1
 }
 
-[[ -n "$sbt_dir" ]] || {
-  sbt_dir=~/.sbt/$(sbt_version)
+if [[ -n $noshare ]]; then
+  addJava "$noshare_opts"
+else
+  [[ -n "$sbt_dir" ]] || {
+    sbt_dir=~/.sbt/$(sbt_version)
+    vlog "Using $sbt_dir as sbt dir, -sbt-dir to override."
+  }
   addJava "-Dsbt.global.base=$sbt_dir"
-  echoerr "Using $sbt_dir as sbt dir, -sbt-dir to override."
-}
+fi
+
+if [[ -r "$jvm_opts_file" ]]; then
+  readarray -t extra_jvm_opts < "$jvm_opts_file"
+elif [[ -n "$JVM_OPTS" ]]; then
+  extra_jvm_opts=( $JVM_OPTS )
+else
+  extra_jvm_opts=( $default_jvm_opts )
+fi
 
 # since sbt 0.7 doesn't understand iflast
-(( ${#residual_args[@]} == 0 )) && residual_args=( "shell" )
+[[ ${#residual_args[@]} -eq 0 ]] && [[ -z "$batch" ]] && residual_args=( "shell" )
+
+# traceLevel is 0.12+
+[[ -n $trace_level ]] && setTraceLevel
+
+[[ -n $log_level ]] && [[ $log_level != Info ]] && logLevalArg="set logLevel in Global := Level.$log_level"
 
 # run sbt
 execRunner "$java_cmd" \
-  $(get_mem_opts $sbt_mem) \
-  $(get_jvm_opts) \
-  ${java_args[@]} \
+  "${extra_jvm_opts[@]}" \
+  "${java_args[@]}" \
   -jar "$sbt_jar" \
+  "$logLevalArg" \
   "${sbt_commands[@]}" \
   "${residual_args[@]}"


### PR DESCRIPTION
Fair few changes to get it to the point where it builds for 2.9.2, 2.9.3 and 2.10.x:
- Updated sbt extras script.
- Increased sbt version to 0.12.3.
- Increased scalaz version to 7.0.0.
- Increased default scala version to 2.10.1.
- Changed cross versions to 2.9.2, 2.9.3 and 2.10.1.
- Removed CrossVersion.full from scalaz and scalacheck deps.
- Removed CrossVersion.full from project (matches scalaz, allows for 2.10.x compat)
- Switch specs version based upon scala version (discussed with Eric T. and this
  is only solution for supporting 2.9.2, 2.9.3 and 2.10.x at the moment).
- Added tests for multiple scala versions to travis config.

If there is anything that you don't won't in the commit, yell and I will tidy it up.
