### PR TITLE
Couple of performance tweaks and some additional functionality.

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -18,6 +18,7 @@ object build extends Build {
   , scalacOptions in (Compile, doc) <++= (baseDirectory in LocalProject("bytestring")).map {
       bd ⇒ List("-sourcepath", bd.getAbsolutePath, "-doc-source-url", "https://github.com/purefn/bytestring/€{FILE_PATH}.scala")
     }
+  , testOptions in Test += Tests.Argument("showtimes")
   )
 
   lazy val bytestring = Project(

--- a/tests/src/test/scala/purefn/bytestring/ByteStringSpec.scala
+++ b/tests/src/test/scala/purefn/bytestring/ByteStringSpec.scala
@@ -31,6 +31,10 @@ class ByteStringSpec extends Spec {
   scalaz.Ordering.EQ
   scalaz.Ordering.GT
 
+  // Potentially slightly nonsense implementations but should suffice in this case.
+  implicit val arrayByteShow: Show[Array[Byte]] = Show.shows(_.toList.toString)
+  implicit val arrayByteEqual: Equal[Array[Byte]] = Equal.equalBy(_.toList)
+
   checkAll("ByteString", order.laws[ByteString])
   checkAll("ByteString", monoid.laws[ByteString])
 
@@ -63,7 +67,7 @@ class ByteStringSpec extends Spec {
 
   // use Short so the sizes don't get too huge
   "replicate" ! check { (n: Short, x: Byte) ⇒
-    replicate(n, x).toStream must be_=== (Stream.fill(n)(x))
+    replicate(n, x).toList must be_=== (List.fill(n)(x))
   }
   
   "unfoldr" ! check { (xs: Stream[Byte]) ⇒
@@ -299,6 +303,10 @@ class ByteStringSpec extends Spec {
 
   "toList" ! check { (xs: List[Byte]) ⇒
     packF(xs).toList must be_=== (xs)
+  }
+
+  "toArray" ! check { (xs: Array[Byte]) ⇒
+    pack(xs).toArray must be_=== (xs)
   }
 
   "toString" ! check { (xs: Stream[Byte]) ⇒


### PR DESCRIPTION
- Removed "lazy" everywhere it was used, it's more than likely going to limit performance.
- Changed concat to be oriented around List rather than Stream which gave about a 15% performance bump.
- Added toArray and another toString method that takes a Charset, also moved the UTF-8 Charset instance so that it's only allocated once.
- Made ByteString.empty a val rather than a def.
- The test for replicate creates a List rather than a Stream, which seems to have improved the running time of that test.
